### PR TITLE
fixed bug for the site contains port

### DIFF
--- a/dist/show-site-all-userjs.gf.user.js
+++ b/dist/show-site-all-userjs.gf.user.js
@@ -46,7 +46,7 @@ var FetchUserjs = function () {
 
         this.homeUrl = 'https://greasyfork.org/zh-CN/scripts/24508';
         this.api = 'https://greasyfork.org/en/scripts/by-site/{host}.json';
-        this.host = location.host.split('.').splice(-2).join('.');
+        this.host = location.hostname.split('.').splice(-2).join('.');
         this.showTime = 10;
         this.quietKey = 'jae_fetch_userjs_quiet';
         this.cacheKey = 'jae_fetch_userjs_cache';

--- a/dist/show-site-all-userjs.user.js
+++ b/dist/show-site-all-userjs.user.js
@@ -46,7 +46,7 @@ var FetchUserjs = function () {
 
         this.homeUrl = 'https://greasyfork.org/zh-CN/scripts/24508';
         this.api = 'https://greasyfork.org/en/scripts/by-site/{host}.json';
-        this.host = location.host.split('.').splice(-2).join('.');
+        this.host = location.hostname.split('.').splice(-2).join('.');
         this.showTime = 10;
         this.quietKey = 'jae_fetch_userjs_quiet';
         this.cacheKey = 'jae_fetch_userjs_cache';

--- a/userscript/main.js
+++ b/userscript/main.js
@@ -2,7 +2,7 @@ class FetchUserjs {
     constructor() {
         this.homeUrl = 'https://greasyfork.org/zh-CN/scripts/24508';
         this.api = 'https://greasyfork.org/en/scripts/by-site/{host}.json';
-        this.host = location.host.split('.').splice(-2).join('.');
+        this.host = location.hostname.split('.').splice(-2).join('.');
         this.showTime = 10;
         this.quietKey = 'jae_fetch_userjs_quiet';
         this.cacheKey = 'jae_fetch_userjs_cache';


### PR DESCRIPTION
sometimes the *.user.js contains the site port, just like
localhost:5678, but greasyfork.org don't include the site
port, domain will be show as 'localhost', so we need hostname
field to get the right domain name.

Signed-off-by: Jackie Liu <liuyun01@kylinos.cn>